### PR TITLE
Add feature to log a specific message for specific amount of times

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,7 +76,7 @@ Log::assertLogged('critical'); // ❌ fails
 
 All assertions are relative to the channel or stack as shown in the previous examples.
 
-### assertLogged($level, $callback = null)
+### assertLogged($level, $callback = null, $times = null)
 
 ```php
 Log::assertLogged('info');
@@ -98,6 +98,20 @@ Log::channel('slack')->assertLogged('alert', function ($message, $context) {
 Log::stack(['bugsnag', 'sentry'])->assertLogged('critical', function ($message, $context) {
     return str_contains($message, 'evasive maneuvers');
 });
+
+// with a callback and times
+
+Log::assertLogged('info', function ($message, $context) {
+    return str_contains($message, 'Donuts');
+}, 42);
+
+Log::channel('slack')->assertLogged('alert', function ($message, $context) {
+    return str_contains($message, '5pm');
+}, 42);
+
+Log::stack(['bugsnag', 'sentry'])->assertLogged('critical', function ($message, $context) {
+    return str_contains($message, 'evasive maneuvers');
+}, 42);
 ```
 
 ### assertLoggedTimes($level, $times = 1)

--- a/src/LogFake.php
+++ b/src/LogFake.php
@@ -27,11 +27,17 @@ class LogFake implements LoggerInterface
      * @param  callable|int|null  $callback
      * @return void
      */
-    public function assertLogged($level, $callback = null)
+    public function assertLogged($level, $callback = null, $times = null)
     {
         if (is_numeric($callback)) {
             return $this->assertLoggedTimes($level, $callback);
         }
+
+        if (is_numeric($times)) {
+            $logged = $this->logged($level, $callback);
+            PHPUnit::assertTrue($logged->count() == $times, "The expected log with level [{$level}] was logged {$logged->count()} times instead of {$times} times in {$this->currentChannel()}.");
+        }
+
 
         PHPUnit::assertTrue(
             $this->logged($level, $callback)->count() > 0,
@@ -116,7 +122,7 @@ class LogFake implements LoggerInterface
      */
     public function hasNotLogged($level)
     {
-        return ! $this->hasLogged($level);
+        return !$this->hasLogged($level);
     }
 
     /**
@@ -302,7 +308,7 @@ class LogFake implements LoggerInterface
      */
     public function stack(array $channels, $channel = null)
     {
-        return $this->driver('Stack:'.$this->createStackChannelName($channels, $channel));
+        return $this->driver('Stack:' . $this->createStackChannelName($channels, $channel));
     }
 
     /**
@@ -358,7 +364,7 @@ class LogFake implements LoggerInterface
         return config('logging.default');
     }
 
-     /**
+    /**
      * Set the default log driver name.
      *
      * @param  string  $name

--- a/tests/FakeLogTest.php
+++ b/tests/FakeLogTest.php
@@ -107,6 +107,47 @@ class LogFakeTest extends TestCase
         }
     }
 
+    public function testAssertLoggedWithCallbackMultipleTimes()
+    {
+        $log = new LogFake;
+
+        try {
+            $log->assertLogged('info', function ($message) {
+                return true;
+            }, 42);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected log with level [info] was logged 0 times instead of 42 times in stack.'));
+        }
+
+        try {
+            $log->channel('channel')->assertLogged('info', function ($message) {
+                return true;
+            }, 42);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected log with level [info] was logged 0 times instead of 42 times in channel.'));
+        }
+
+        try {
+            $log->stack(['channel'], 'name')->assertLogged('info', function ($message) {
+                return true;
+            }, 42);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected log with level [info] was logged 0 times instead of 42 times in Stack:name.channel.'));
+        }
+
+        try {
+            $log->stack(['channel'], 'name')->assertLogged('info', function ($message) {
+                return true;
+            }, 42);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected log with level [info] was logged 0 times instead of 42 times in Stack:name.channel.'));
+        }
+    }
+
     public function testAssertLoggedTimes()
     {
         $log = new LogFake;
@@ -409,7 +450,7 @@ class LogFakeTest extends TestCase
 
     public function testAssertLoggedInStackDotNotatesSortedChannels()
     {
-        $this->assertSame('Stack:name.a.b.c', (new LogFake)->stack(['c','b', 'a'], 'name')->currentChannel());
+        $this->assertSame('Stack:name.a.b.c', (new LogFake)->stack(['c', 'b', 'a'], 'name')->currentChannel());
     }
 
     public function testClosuresProvideMessageAndContext()


### PR DESCRIPTION
Hi @timacdonald and thank you for your great work here.

I've needed the following feature in `log-fake` so I've implemented it:

I want to ensure that a specific message was logged `x` times.

With my added feature you can do something like:

```
Log::assertLogged('info', function ($message) {
      return Str::contains($message, 'Happy birthday');
}, 4);
```

In the above example it's asserted that the message containing `Happy birthday` was logged 4 times.


I've implemented the feature as a non-breaking change so everything should work fine for all installations.