### PR TITLE
add assertSameLoggedMessage

### DIFF
--- a/src/LogFake.php
+++ b/src/LogFake.php
@@ -80,6 +80,23 @@ class LogFake implements LoggerInterface
     }
 
     /**
+     * Assert log message.
+     *
+     * @param  string  $level
+     * @param  string  $message
+     * @return void
+     */
+    public function assertSameLoggedMessage(string $level, string $message) : void
+    {
+        PHPUnit::assertTrue(
+            $this->logged($level, function ($logMessage, $context) use ($message) {
+                return mb_strpos($logMessage, $message) !== false;
+            })->count() > 0,
+            "The expected log with level [{$level}] that was logged in {$this->currentChannel()} has not the same message as {$message}."
+        );
+    }
+
+    /**
      * Get all of the logs matching a truth-test callback.
      *
      * @param  string  $level
@@ -290,7 +307,7 @@ class LogFake implements LoggerInterface
      */
     public function driver($driver = null)
     {
-        return new ChannelFake($this, $driver);
+        return new ChannelFake($this, $driver ?? $this->getDefaultDriver());
     }
 
     /**
@@ -358,12 +375,12 @@ class LogFake implements LoggerInterface
         return config('logging.default');
     }
 
-     /**
-     * Set the default log driver name.
-     *
-     * @param  string  $name
-     * @return void
-     */
+    /**
+    * Set the default log driver name.
+    *
+    * @param  string  $name
+    * @return void
+    */
     public function setDefaultDriver($name)
     {
         config()->set('logging.default', $name);

--- a/tests/FakeLogTest.php
+++ b/tests/FakeLogTest.php
@@ -234,6 +234,10 @@ class LogFakeTest extends TestCase
         $log->info($this->message);
         $this->assertFalse($log->logged('info')->isEmpty());
 
+        $this->assertFalse($log->channel('stack')->logged('info')->isEmpty());
+        $log->info($this->message);
+        $this->assertCount(2, $log->channel('stack')->logged('info'));
+
         $this->assertTrue($log->channel('channel')->logged('info')->isEmpty());
         $log->channel('channel')->info($this->message);
         $this->assertFalse($log->channel('channel')->logged('info')->isEmpty());
@@ -430,5 +434,38 @@ class LogFakeTest extends TestCase
             $this->assertSame(['key' => 'expected'], $context);
             return false;
         });
+    }
+
+    public function testAssertSameLoggedMessage()
+    {
+        $log = new LogFake;
+
+        $log->alert('example alert log');
+        $log->info('example info log');
+
+        $log->assertLogged('alert');
+
+        $log->assertSameLoggedMessage('alert', 'example alert log');
+        $log->assertSameLoggedMessage('info', 'example info log');
+
+        $log->assertSameLoggedMessage('alert', 'example alert');
+        $log->assertSameLoggedMessage('info', 'example info');
+
+        $log->assertSameLoggedMessage('alert', 'example');
+        $log->assertSameLoggedMessage('info', 'example');
+
+        try {
+            $log->assertSameLoggedMessage('alert', 'fake alert message');
+            $this->fail('it is not the right alert message');
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected log with level [alert] that was logged in stack has not the same message as fake alert message.'));
+        }
+
+        try {
+            $log->assertSameLoggedMessage('info', 'fake info message');
+            $this->fail('it is not the right info message');
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected log with level [info] that was logged in stack has not the same message as fake info message.'));
+        }
     }
 }


### PR DESCRIPTION
You can assert if the log has the same message easier than doing the callback.

```
$log->alert('example alert log');
$log->assertSameLoggedMessage('alert', 'example alert log');
```
