### PR TITLE
channel method return implements psr/LoggerInterface

### DIFF
--- a/src/ChannelFake.php
+++ b/src/ChannelFake.php
@@ -2,19 +2,38 @@
 
 namespace TiMacDonald\Log;
 
-class ChannelFake
+use Psr\Log\LoggerInterface;
+
+class ChannelFake extends FakeLogger implements LoggerInterface
 {
+    /**
+     * @var $log LogFake
+     */
     protected $log;
 
+    /**
+     * @var $name string
+     */
     protected $name;
 
+    /**
+     * ChannelFake constructor.
+     *
+     * @param $log
+     * @param $name
+     */
     public function __construct($log, $name)
     {
         $this->log = $log;
-
         $this->name = $name;
     }
 
+    /**
+     * @param $method
+     * @param $arguments
+     *
+     * @return mixed
+     */
     public function __call($method, $arguments)
     {
         $this->log->setCurrentChannel($this->name);
@@ -24,5 +43,23 @@ class ChannelFake
         $this->log->setCurrentChannel(null);
 
         return $result;
+    }
+
+    /**
+     * Log a message to the logs.
+     *
+     * @param string $level
+     * @param string $message
+     * @param array  $context
+     *
+     * @return void
+     */
+    public function log($level, $message, array $context = [])
+    {
+        $this->log->setCurrentChannel($this->name);
+
+        $this->log->log($level, $message, $context);
+
+        $this->log->setCurrentChannel(null);
     }
 }

--- a/src/FakeLogger.php
+++ b/src/FakeLogger.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace TiMacDonald\Log;
+
+abstract class FakeLogger
+{
+    /**
+     * Log an emergency message to the logs.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return void
+     */
+    public function emergency($message, array $context = [])
+    {
+        $this->log(__FUNCTION__, $message, $context);
+    }
+
+    /**
+     * Log an alert message to the logs.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return void
+     */
+    public function alert($message, array $context = [])
+    {
+        $this->log(__FUNCTION__, $message, $context);
+    }
+
+    /**
+     * Log a critical message to the logs.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return void
+     */
+    public function critical($message, array $context = [])
+    {
+        $this->log(__FUNCTION__, $message, $context);
+    }
+
+    /**
+     * Log an error message to the logs.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return void
+     */
+    public function error($message, array $context = [])
+    {
+        $this->log(__FUNCTION__, $message, $context);
+    }
+
+    /**
+     * Log a warning message to the logs.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return void
+     */
+    public function warning($message, array $context = [])
+    {
+        $this->log(__FUNCTION__, $message, $context);
+    }
+
+    /**
+     * Log a notice to the logs.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return void
+     */
+    public function notice($message, array $context = [])
+    {
+        $this->log(__FUNCTION__, $message, $context);
+    }
+
+    /**
+     * Log an informational message to the logs.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return void
+     */
+    public function info($message, array $context = [])
+    {
+        $this->log(__FUNCTION__, $message, $context);
+    }
+
+    /**
+     * Log a debug message to the logs.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return void
+     */
+    public function debug($message, array $context = [])
+    {
+        $this->log(__FUNCTION__, $message, $context);
+    }
+
+    /**
+     * @param       $level
+     * @param       $message
+     * @param array $context
+     *
+     * @return mixed
+     */
+    abstract public function log($level, $message, array $context = []);
+
+}

--- a/src/LogFake.php
+++ b/src/LogFake.php
@@ -6,7 +6,7 @@ use Psr\Log\LoggerInterface;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\Assert as PHPUnit;
 
-class LogFake implements LoggerInterface
+class LogFake extends FakeLogger implements LoggerInterface
 {
     /**
      * All of the created logs.
@@ -157,102 +157,6 @@ class LogFake implements LoggerInterface
         return Collection::make($this->logs)->filter(function ($log) {
             return $this->currentChannelIs($log['channel']);
         });
-    }
-
-    /**
-     * Log an emergency message to the logs.
-     *
-     * @param  string  $message
-     * @param  array  $context
-     * @return void
-     */
-    public function emergency($message, array $context = [])
-    {
-        $this->log(__FUNCTION__, $message, $context);
-    }
-
-    /**
-     * Log an alert message to the logs.
-     *
-     * @param  string  $message
-     * @param  array  $context
-     * @return void
-     */
-    public function alert($message, array $context = [])
-    {
-        $this->log(__FUNCTION__, $message, $context);
-    }
-
-    /**
-     * Log a critical message to the logs.
-     *
-     * @param  string  $message
-     * @param  array  $context
-     * @return void
-     */
-    public function critical($message, array $context = [])
-    {
-        $this->log(__FUNCTION__, $message, $context);
-    }
-
-    /**
-     * Log an error message to the logs.
-     *
-     * @param  string  $message
-     * @param  array  $context
-     * @return void
-     */
-    public function error($message, array $context = [])
-    {
-        $this->log(__FUNCTION__, $message, $context);
-    }
-
-    /**
-     * Log a warning message to the logs.
-     *
-     * @param  string  $message
-     * @param  array  $context
-     * @return void
-     */
-    public function warning($message, array $context = [])
-    {
-        $this->log(__FUNCTION__, $message, $context);
-    }
-
-    /**
-     * Log a notice to the logs.
-     *
-     * @param  string  $message
-     * @param  array  $context
-     * @return void
-     */
-    public function notice($message, array $context = [])
-    {
-        $this->log(__FUNCTION__, $message, $context);
-    }
-
-    /**
-     * Log an informational message to the logs.
-     *
-     * @param  string  $message
-     * @param  array  $context
-     * @return void
-     */
-    public function info($message, array $context = [])
-    {
-        $this->log(__FUNCTION__, $message, $context);
-    }
-
-    /**
-     * Log a debug message to the logs.
-     *
-     * @param  string  $message
-     * @param  array  $context
-     * @return void
-     */
-    public function debug($message, array $context = [])
-    {
-        $this->log(__FUNCTION__, $message, $context);
     }
 
     /**

--- a/tests/FakeLogTest.php
+++ b/tests/FakeLogTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Psr\Log\LoggerInterface;
 use stdClass;
 use TiMacDonald\Log\LogFake;
 use PHPUnit\Framework\TestCase;
@@ -267,6 +268,13 @@ class LogFakeTest extends TestCase
         }
     }
 
+
+    public function testChannelLoggerInstanceOfLoggerInterface()
+    {
+        $log = new LogFake;
+        $this->assertInstanceOf(LoggerInterface::class, $log->channel('channel'));
+    }
+
     public function testLogged()
     {
         $log = new LogFake;
@@ -460,15 +468,18 @@ class LogFakeTest extends TestCase
 
         $items = $log->logged('info', function ($message, $context) {
             $this->assertSame(['key' => 'expected'], $context);
+
             return true;
         });
         $this->assertTrue($items->isNotEmpty());
         $log->assertLogged('info', function ($message, $context) {
             $this->assertSame(['key' => 'expected'], $context);
+
             return true;
         });
         $log->assertNotLogged('info', function ($message, $context) {
             $this->assertSame(['key' => 'expected'], $context);
+
             return false;
         });
     }


### PR DESCRIPTION
In laravel, the channel method returns an implementation of the LoggerInterface interface. So I added an abstract class and made ChanelFake an implementation of LoggerInterface.

This will fix errors if your code uses a valid factory type:

```
public function getMyLogger(): \Psr\Log\LoggerInterface  
{  
      return  \Illuminate\Support\Facades\Log::channel('channel');  
}  
```

I also added a small test checking return interface. 
