### PR TITLE
Laravel 7.x Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/config": "~5.6|^6.0",
-        "illuminate/container": "~5.6|^6.0",
-        "illuminate/support": "~5.6|^6.0",
+        "illuminate/config": "~5.6|^6.0|^7.0",
+        "illuminate/container": "~5.6|^6.0|^7.0",
+        "illuminate/support": "~5.6|^6.0|^7.0",
         "phpunit/phpunit": "^7.0|^8.0|^9.0",
         "psr/log": "^1.0"
     },


### PR DESCRIPTION
PR supports upgrades to Laravel 7.x.  I've ran this on a Laravel 7 instance and didn't encounter any problems.