### PR TITLE
Add the ability to inspect logs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -203,9 +203,11 @@ Log::stack(['bugsnag', 'sentry'])->assertNothingLogged();
 
 Sometimes when debugging tests it's useful to be able to take a peek at the stack of messages that have been logged. There are a couple of helpers to assist with this.
 
-### dump()
+### dump($level = null)
 
 Dump all logs in the current channel. If not in a specific channel, all logs are dumped.
+
+You can optionally specify a specific level to filter to.
 
 For each logged message an associative array containing the following keys will be output:
 - `level`
@@ -237,7 +239,7 @@ Log::dump();
 
 Log::channel('single')->dump();
 
-// ^ array:1 [
+// array:1 [
 //   1 => array:4 [
 //     "level" => "debug"
 //     "message" => "bar message"
@@ -246,11 +248,15 @@ Log::channel('single')->dump();
 //   ]
 // ]
 
+Log::channel('single')->dump('info');
+
+// []
+
 ```
 
-### dd()
+### dd($level = null)
 
-Similar to `dump`, but also ends the execution of the test.
+Works the same as `dump`, but also ends the execution of the test.
 
 ```php
 <?php
@@ -260,7 +266,7 @@ Log::channel('single')->debug('bar message');
 
 Log::channel('slack')->dd();
 
-// ^ array:1 [
+// array:1 [
 //   1 => array:4 [
 //     "level" => "info"
 //     "message" => "foo message"

--- a/readme.md
+++ b/readme.md
@@ -199,6 +199,79 @@ Log::channel('slack')->assertNothingLogged();
 Log::stack(['bugsnag', 'sentry'])->assertNothingLogged();
 ```
 
+## Inspection
+
+Sometimes when debugging tests it's useful to be able to take a peek at the stack of messages that have been logged. There are a couple of helpers to assist with this.
+
+### dump()
+
+Dump all logs in the current channel. If not in a specific channel, all logs are dumped.
+
+For each logged message an associative array containing the following keys will be output:
+- `level`
+- `message`
+- `context`
+- `channel`
+
+```php
+<?php
+
+Log::channel('slack')->info('foo message');
+Log::channel('single')->debug('bar message');
+Log::dump();
+
+// array:2 [
+//   0 => array:4 [
+//     "level" => "info"
+//     "message" => "foo message"
+//     "context" => []
+//     "channel" => "slack"
+//   ]
+//   1 => array:4 [
+//     "level" => "debug"
+//     "message" => "bar message"
+//     "context" => []
+//     "channel" => "single"
+//   ]
+// ]
+
+Log::channel('single')->dump();
+
+// ^ array:1 [
+//   1 => array:4 [
+//     "level" => "debug"
+//     "message" => "bar message"
+//     "context" => []
+//     "channel" => "single"
+//   ]
+// ]
+
+```
+
+### dd()
+
+Similar to `dump`, but also ends the execution of the test.
+
+```php
+<?php
+
+Log::channel('slack')->info('foo message');
+Log::channel('single')->debug('bar message');
+
+Log::channel('slack')->dd();
+
+// ^ array:1 [
+//   1 => array:4 [
+//     "level" => "info"
+//     "message" => "foo message"
+//     "context" => []
+//     "channel" => "slack"
+//   ]
+// ]
+
+```
+
+
 ## Credits
 
 - [Tim MacDonald](https://github.com/timacdonald)

--- a/src/LogFake.php
+++ b/src/LogFake.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Collection;
 use function is_callable;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\VarDumper\VarDumper;
 
 class LogFake implements LoggerInterface
 {
@@ -276,6 +277,37 @@ class LogFake implements LoggerInterface
      */
     public function getLogger()
     {
+        return $this;
+    }
+
+    /**
+     * Dump all logs in the current channel and end the script
+     *
+     * @return void
+     */
+    public function dd()
+    {
+        $this->dump();
+
+        exit(1);
+    }
+
+    /**
+     * Dump all logs in the current channel
+     *
+     * @return self
+     */
+    public function dump()
+    {
+        $logs = $this->logs;
+
+        if ($this->currentChannel) {
+            $logs = $this->logsInCurrentChannel()
+                ->all();
+        }
+
+        VarDumper::dump($logs);
+
         return $this;
     }
 

--- a/src/LogFake.php
+++ b/src/LogFake.php
@@ -283,11 +283,13 @@ class LogFake implements LoggerInterface
     /**
      * Dump all logs in the current channel and end the script
      *
+     * @param mixed $level optional level to filter to
+     *
      * @return void
      */
-    public function dd()
+    public function dd($level = null)
     {
-        $this->dump();
+        $this->dump($level);
 
         exit(1);
     }
@@ -295,18 +297,22 @@ class LogFake implements LoggerInterface
     /**
      * Dump all logs in the current channel
      *
+     * @param mixed $level optional level to filter to
+     *
      * @return self
      */
-    public function dump()
+    public function dump($level = null)
     {
-        $logs = $this->logs;
+        $logs = $this->currentChannel ? $this->logsInCurrentChannel()
+            : collect($this->logs);
 
-        if ($this->currentChannel) {
-            $logs = $this->logsInCurrentChannel()
-                ->all();
+        if ($level) {
+            $logs = $logs->filter(function (array $log) use ($level): bool {
+                return $log['level'] === $level;
+            });
         }
 
-        VarDumper::dump($logs);
+        VarDumper::dump($logs->all());
 
         return $this;
     }


### PR DESCRIPTION
# What is it?

In debugging complex tests / code it can be really useful to just get a dump of everything that has been logged. Helps you quickly identify & resolve issues - even without a debugger.

This PR adds methods for `dd` and `dump` to the list of useful helpers provided by this package - allowing you to easily examine what is going on in a particular channel / level  or globally. These methods work similar to [Collection::dump](https://laravel.com/docs/8.x/collections#method-dump) and [Collection::dd](https://laravel.com/docs/8.x/collections#method-dd) - you simply call `Log::dd()` or e.g. `Log::channel('slack')->dd('debug')` to get a dump of all logged messages.

- [x] Added `dump` method
- [x] Added `dd` method
- [x] Respect current channel
- [x] Ability to filter level
- [x] Added tests - all passing
- [x] Updated documentation

From the updated readme docs:

## Inspection

Sometimes when debugging tests it's useful to be able to take a peek at the stack of messages that have been logged. There are a couple of helpers to assist with this.

### dump($level = null)

Dump all logs in the current channel. If not in a specific channel, all logs are dumped.

You can optionally specify a specific level to filter to.

For each logged message an associative array containing the following keys will be output:
- `level`
- `message`
- `context`
- `channel`

```php
<?php

Log::channel('slack')->info('foo message');
Log::channel('single')->debug('bar message');
Log::dump();

// array:2 [
//   0 => array:4 [
//     "level" => "info"
//     "message" => "foo message"
//     "context" => []
//     "channel" => "slack"
//   ]
//   1 => array:4 [
//     "level" => "debug"
//     "message" => "bar message"
//     "context" => []
//     "channel" => "single"
//   ]
// ]

Log::channel('single')->dump();

// array:1 [
//   1 => array:4 [
//     "level" => "debug"
//     "message" => "bar message"
//     "context" => []
//     "channel" => "single"
//   ]
// ]

Log::channel('single')->dump('info');

// []

```

### dd($level = null)

Works the same as `dump`, but also ends the execution of the test.

```php
<?php

Log::channel('slack')->info('foo message');
Log::channel('single')->debug('bar message');

Log::channel('slack')->dd();

// array:1 [
//   1 => array:4 [
//     "level" => "info"
//     "message" => "foo message"
//     "context" => []
//     "channel" => "slack"
//   ]
// ]

```
