### PR TITLE
Allow a more loose psr/log dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "illuminate/container": "~5.6.0 || ~5.7.0 || ~5.8.0 || ^6.0 || ^7.0 || ^8.0",
         "illuminate/support": "~5.6.0 || ~5.7.0 || ~5.8.0 || ^6.0 || ^7.0 || ^8.0",
         "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0 || ^2.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.0",


### PR DESCRIPTION
Hi, I've opened this pull request to allow psr/log dependency to support either 1.0 or 2.0 otherwise I am not able to install this package on a fresh Laravel 8 + Passport setup.

This update should not be, and it's not in my local test env, a breaking change. If there is a motivation to leave it to 1.0 please let me know