### PR TITLE
Return types to Laravel 9 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,9 +64,9 @@ jobs:
     name: 'PHP: ${{ matrix.php }}; Laravel: ${{ matrix.laravel }}; PHPUnit: ${{ matrix.phpunit }}; Dependecies: ${{ matrix.dependency-version }}'
     strategy:
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0']
-        laravel: ['~5.6.0', '~5.7.0', '~5.8.0', '^6.0', '^7.0', '^8.0']
-        phpunit: ['^7.0', '^8.0', '^9.0']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', 8.0]
+        laravel: ['~5.6.0', '~5.7.0', '~5.8.0', '^6.0', '^7.0', '^8.0', 9.0]
+        phpunit: ['^7.0', '^8.0', '^9.0', 8.0]
         dependency-version: ['prefer-lowest', 'prefer-stable']
         exclude:
             - laravel: '^6.0'

--- a/composer.json
+++ b/composer.json
@@ -18,16 +18,16 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "illuminate/config": "~5.6.0 || ~5.7.0 || ~5.8.0 || ^6.0 || ^7.0 || ^8.0",
-        "illuminate/container": "~5.6.0 || ~5.7.0 || ~5.8.0 || ^6.0 || ^7.0 || ^8.0",
-        "illuminate/support": "~5.6.0 || ~5.7.0 || ~5.8.0 || ^6.0 || ^7.0 || ^8.0",
+        "illuminate/config": "~5.6.0 || ~5.7.0 || ~5.8.0 || ^6.0 || ^7.0 || ^8.0|^9.0",
+        "illuminate/container": "~5.6.0 || ~5.7.0 || ~5.8.0 || ^6.0 || ^7.0 || ^8.0|^9.0",
+        "illuminate/support": "~5.6.0 || ~5.7.0 || ~5.8.0 || ^6.0 || ^7.0 || ^8.0|^9.0",
         "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
-        "psr/log": "^1.0 || ^2.0"
+        "psr/log": "^1.0 || ^2.0|^3.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.0",
-        "infection/infection": "^0.18.2",
-        "phpstan/phpstan": "^0.12",
+        "infection/infection": "^0.18.2|^0.26",
+        "phpstan/phpstan": "^0.12|^1.4",
         "timacdonald/php-style": "dev-master",
         "vimeo/psalm": "^4.1"
     },

--- a/src/ChannelFake.php
+++ b/src/ChannelFake.php
@@ -41,7 +41,7 @@ class ChannelFake implements LoggerInterface
      *
      * @return void
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         $this->proxy(function () use ($level, $message, $context): void {
             $this->log->log($level, $message, $context);

--- a/src/LogFake.php
+++ b/src/LogFake.php
@@ -164,7 +164,7 @@ class LogFake implements LoggerInterface
      *
      * @return void
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         $this->logs[] = [
             'level' => $level,
@@ -180,7 +180,7 @@ class LogFake implements LoggerInterface
      *
      * @return void
      */
-    public function write($level, $message, array $context = [])
+    public function write($level, $message, array $context = []): void
     {
         $this->log($level, $message, $context);
     }

--- a/src/LogHelpers.php
+++ b/src/LogHelpers.php
@@ -13,7 +13,7 @@ trait LogHelpers
      *
      * @return void
      */
-    public function emergency($message, array $context = [])
+    public function emergency($message, array $context = []): void
     {
         $this->log(__FUNCTION__, $message, $context);
     }
@@ -25,7 +25,7 @@ trait LogHelpers
      *
      * @return void
      */
-    public function alert($message, array $context = [])
+    public function alert($message, array $context = []): void
     {
         $this->log(__FUNCTION__, $message, $context);
     }
@@ -37,7 +37,7 @@ trait LogHelpers
      *
      * @return void
      */
-    public function critical($message, array $context = [])
+    public function critical($message, array $context = []): void
     {
         $this->log(__FUNCTION__, $message, $context);
     }
@@ -49,7 +49,7 @@ trait LogHelpers
      *
      * @return void
      */
-    public function error($message, array $context = [])
+    public function error($message, array $context = []): void
     {
         $this->log(__FUNCTION__, $message, $context);
     }
@@ -61,7 +61,7 @@ trait LogHelpers
      *
      * @return void
      */
-    public function warning($message, array $context = [])
+    public function warning($message, array $context = []): void
     {
         $this->log(__FUNCTION__, $message, $context);
     }
@@ -73,7 +73,7 @@ trait LogHelpers
      *
      * @return void
      */
-    public function notice($message, array $context = [])
+    public function notice($message, array $context = []): void
     {
         $this->log(__FUNCTION__, $message, $context);
     }
@@ -85,7 +85,7 @@ trait LogHelpers
      *
      * @return void
      */
-    public function info($message, array $context = [])
+    public function info($message, array $context = []): void
     {
         $this->log(__FUNCTION__, $message, $context);
     }
@@ -97,7 +97,7 @@ trait LogHelpers
      *
      * @return void
      */
-    public function debug($message, array $context = [])
+    public function debug($message, array $context = []): void
     {
         $this->log(__FUNCTION__, $message, $context);
     }


### PR DESCRIPTION
This PR adds return types (`void`) to all the methods implemented in the PSR3 interface so that this package is compliant with all the versions (1, 2 and 3) of the [psr/log](https://packagist.org/packages/psr/log) package (see my thoughts [here](https://github.com/timacdonald/log-fake/pull/32#issuecomment-1034767288)).

This would require a new major version to my knowledge. @timacdonald might be worth adding return types to the other public methods as well in that case?

By the way this has been submitted as a PR to the existing PR #32 in order to make that work, so if that can be merged then this PR can be closed: https://github.com/laravel-shift/log-fake/pull/1