### PR TITLE
Laravel 11.x Compatibility (fixed)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "illuminate/support": "^9.0 || ^10.0 || ^11.0",
         "phpunit/phpunit": "^9.0 || ^10.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "symfony/var-dumper": "^6.0"
+        "symfony/var-dumper": "^6.0 || ^7.0"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -18,18 +18,18 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/collections": "^9.0 || ^10.0",
-        "illuminate/contracts": "^9.0 || ^10.0",
-        "illuminate/log": "^9.0 || ^10.0",
-        "illuminate/support": "^9.0 || ^10.0",
+        "illuminate/collections": "^9.0 || ^10.0 || ^11.0",
+        "illuminate/contracts": "^9.0 || ^10.0 || ^11.0",
+        "illuminate/log": "^9.0 || ^10.0 || ^11.0",
+        "illuminate/support": "^9.0 || ^10.0 || ^11.0",
         "phpunit/phpunit": "^9.0 || ^10.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/var-dumper": "^6.0"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.4",
-        "illuminate/config": "^9.0 || ^10.0",
-        "illuminate/container": "^9.0 || ^10.0",
+        "illuminate/config": "^9.0 || ^10.0 || ^11.0",
+        "illuminate/container": "^9.0 || ^10.0 || ^11.0",
         "timacdonald/callable-fake": "^1.5"
     },
     "config": {


### PR DESCRIPTION
Based on the Laravel Shift PR. Installed and tested on my own project.

⚗️ Using this package? If you would like to help test these changes or believe them to be compatible, you may update your project to reference this branch.

To do so, temporarily add Shift's fork to the repositories property of your composer.json:

```json
{
    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/markwalet/log-fake.git"
        }
    ]
}
```

Then update your dependency constraint to reference this branch:

```json
{
    "require": {
        "timacdonald/log-fake": "dev-l11-compatibility",
    }
}
```
Finally, run: `composer update`