### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ public function testItLogsWhenAUserAuthenticates()
      * Finally you can make assertions against the log channels, stacks, etc. to
      * ensure the expected logging occurred in your implementation.
      */
-    Log::assertLogged(fn (LogEntry $log) =>
+    Log::channel('stack')->assertLogged(fn (LogEntry $log) =>
         $log->level === 'info'
         && $log->message === 'User logged in.' 
         && $log->context === ['user_id' => 5]

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,36 @@ You can install using [composer](https://getcomposer.org/):
 ```sh
 composer require timacdonald/log-fake --dev
 ```
+## Example Setup
+
+```php
+<?php
+use Illuminate\Container\Container;
+use Illuminate\Config\Repository;
+use Illuminate\Log\LogManager;
+use Illuminate\Support\Facades\Facade;
+use TiMacDonald\Log\LogFake;
+
+abstract class TestCase extends PHPUnit\Framework\TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $app = Container::setInstance(new Container());
+
+        $app->singleton('config', fn() => new Repository(['logging' => ['default' => 'stack']]));
+        /** @phpstan-ignore argument.type */
+        $app->singleton('log', fn() => new LogManager($app));
+
+        /** @phpstan-ignore argument.type */
+        Facade::setFacadeApplication($app);
+        Facade::clearResolvedInstances();
+
+        LogFake::bind();
+    }
+}
+```
 
 ## Basic usage
 


### PR DESCRIPTION
**PR Description:**

Fixed incorrect usage of `assertLogged` method in `LogFake`. The method is not static and needs to be called against a channel (e.g., using `stack` as the default). Updated the documentation to reflect the correct usage.

Changes:
- Corrected `assertLogged` usage in examples.
- Updated documentation to show the correct method call.