### PR TITLE
Adding support for Laravel 12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,8 @@ on:
       - master
 
 jobs:
-  checks:
-    name: Check
+  static-analysis:
+    name: Static analysis
     runs-on: ubuntu-latest
 
     steps:
@@ -25,15 +25,15 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
+          key: ${{ runner.os }}-php-8.2-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-php-8.2-composer-
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.2
-          coverage: pcov
-          tools: infection, pint, phpstan
+          tools: phpstan
+          coverage: none
 
       - name: Install dependencies
         run: composer install
@@ -41,14 +41,62 @@ jobs:
       - name: Check platform requirements
         run: composer check-platform-reqs
 
+      - name: PHPStan
+        run: phpstan
+
+
+  code-style:
+    name: Code style
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          ## Temporary version pin as 21.0.0 is broken
+          tools: pint:20.0.0
+          coverage: none
+
       - name: Pint
         run: pint --test
+
+
+  mutation-testing:
+    name: Mutation testing
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-8.4-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-php-8.4-composer-
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          tools: infection
+          coverage: pcov
+
+      - name: Install dependencies
+        run: composer install
 
       - name: Infection
         run: infection --show-mutations
 
-      - name: PHPStan
-        run: phpstan
 
   tests:
     name: PHP ${{ matrix.php }} Illuminate ${{ matrix.illuminate }} PHPUnit ${{ matrix.phpunit }}
@@ -97,4 +145,4 @@ jobs:
         run: if [ -f "./phpunit.${{ matrix.phpunit }}.xml" ]; then cp ./phpunit.${{ matrix.phpunit }}.xml ./phpunit.xml; fi
 
       - name: PHPUnit
-        run: ./vendor/bin/phpunit --do-not-cache-result
+        run: ./vendor/bin/phpunit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,6 +106,9 @@ jobs:
         php: [8.2, 8.3, 8.4]
         illuminate: [11, 12]
         phpunit: [10, 11, 12]
+        exclude:
+          - phpunit: 12
+            php: 8.2
 
     steps:
       - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,14 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.1, 8.2, 8.3]
-        illuminate: [10, 11, 12]
-        phpunit: [10, 11]
-        exclude:
-          - php: 8.1
-            illuminate: 11
-          - php: 8.1
-            phpunit: 11
+        php: [8.2, 8.3, 8.4]
+        illuminate: [11, 12]
+        phpunit: [10, 11, 12]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         php: ['8.1', '8.2', '8.3']
-        illuminate: ['10', '11']
+        illuminate: ['10', '11', '12']
         phpunit: ['10', '11']
         exclude:
           - php: '8.1'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,8 +57,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.4
-          ## Temporary version pin as 21.0.0 is broken
-          tools: pint:20.0.0
+          ## Temporary version pin as 1.21.0 is broken
+          tools: pint:1.20.0
           coverage: none
 
       - name: Pint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles("**/composer.json") }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Setup PHP
@@ -71,7 +71,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php-${{ matrix.php }}-illuminate-${{ matrix.illuminate }}-phpunit-${{ matrix.phpunit }}-composer-${{ hashFiles("**/composer.json") }}
+          key: ${{ runner.os }}-php-${{ matrix.php }}-illuminate-${{ matrix.illuminate }}-phpunit-${{ matrix.phpunit }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-illuminate-${{ matrix.illuminate }}-phpunit-${{ matrix.phpunit }}-composer-
 
       - name: Setup PHP

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,14 +2,17 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
 
 jobs:
   checks:
+    name: Check
     runs-on: ubuntu-latest
-    name: 'Check'
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -22,13 +25,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-composer-${{ hashFiles("**/composer.json") }}
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: 8.3
           coverage: pcov
           tools: infection, pint, phpstan
 
@@ -48,18 +51,19 @@ jobs:
         run: phpstan
 
   tests:
+    name: PHP ${{ matrix.php }} Illuminate ${{ matrix.illuminate }} PHPUnit ${{ matrix.phpunit }}
     runs-on: ubuntu-latest
-    name: 'PHP ${{ matrix.php }} Illuminate ${{ matrix.illuminate }} PHPUnit ${{ matrix.phpunit }}'
     strategy:
       matrix:
-        php: ['8.1', '8.2', '8.3']
-        illuminate: ['10', '11', '12']
-        phpunit: ['10', '11']
+        php: [8.1, 8.2, 8.3]
+        illuminate: [10, 11, 12]
+        phpunit: [10, 11]
         exclude:
-          - php: '8.1'
-            illuminate: '11'
-          - php: '8.1'
-            phpunit: '11'
+          - php: 8.1
+            illuminate: 11
+          - php: 8.1
+            phpunit: 11
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -72,7 +76,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php-${{ matrix.php }}-illuminate-${{ matrix.illuminate }}-phpunit-${{ matrix.phpunit }}-composer-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-php-${{ matrix.php }}-illuminate-${{ matrix.illuminate }}-phpunit-${{ matrix.phpunit }}-composer-${{ hashFiles("**/composer.json") }}
           restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-illuminate-${{ matrix.illuminate }}-phpunit-${{ matrix.phpunit }}-composer-
 
       - name: Setup PHP
@@ -95,7 +99,7 @@ jobs:
           composer update
 
       - name: Configure PHPUnit
-        run: "if [ -f './phpunit.${{ matrix.phpunit }}.xml' ]; then cp ./phpunit.${{ matrix.phpunit }}.xml ./phpunit.xml; fi"
+        run: if [ -f "./phpunit.${{ matrix.phpunit }}.xml" ]; then cp ./phpunit.${{ matrix.phpunit }}.xml ./phpunit.xml; fi
 
       - name: PHPUnit
         run: ./vendor/bin/phpunit --do-not-cache-result

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.2
           coverage: pcov
           tools: infection, pint, phpstan
 

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,6 @@
         "preferred-install": "dist",
         "sort-packages": true
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,17 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/collections": "^10.0 || ^11.0",
-        "illuminate/contracts": "^10.0 || ^11.0",
-        "illuminate/log": "^10.0 || ^11.0",
-        "illuminate/support": "^10.0 || ^11.0",
-        "phpunit/phpunit": "^10.0 || ^11.0",
+        "illuminate/collections": "^10.0 || ^11.0 || ^12.0",
+        "illuminate/contracts": "^10.0 || ^11.0 || ^12.0",
+        "illuminate/log": "^10.0 || ^11.0 || ^12.0",
+        "illuminate/support": "^10.0 || ^11.0 || ^12.0",
+        "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/var-dumper": "^6.0 || ^7.0"
     },
     "require-dev": {
-        "illuminate/config": "^10.0 || ^11.0",
-        "illuminate/container": "^10.0 || ^11.0",
+        "illuminate/config": "^10.0 || ^11.0 || ^12.0",
+        "illuminate/container": "^10.0 || ^11.0 || ^12.0",
         "timacdonald/callable-fake": "^1.0"
     },
     "autoload": {
@@ -45,6 +45,6 @@
         "preferred-install": "dist",
         "sort-packages": true
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -17,18 +17,18 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "illuminate/collections": "^10.0 || ^11.0 || ^12.0",
-        "illuminate/contracts": "^10.0 || ^11.0 || ^12.0",
-        "illuminate/log": "^10.0 || ^11.0 || ^12.0",
-        "illuminate/support": "^10.0 || ^11.0 || ^12.0",
+        "php": "^8.2",
+        "illuminate/collections": "^11.0 || ^12.0",
+        "illuminate/contracts": "^11.0 || ^12.0",
+        "illuminate/log": "^11.0 || ^12.0",
+        "illuminate/support": "^11.0 || ^12.0",
         "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "symfony/var-dumper": "^6.0 || ^7.0"
+        "symfony/var-dumper": "^7.0"
     },
     "require-dev": {
-        "illuminate/config": "^10.0 || ^11.0 || ^12.0",
-        "illuminate/container": "^10.0 || ^11.0 || ^12.0",
+        "illuminate/config": "^11.0 || ^12.0",
+        "illuminate/container": "^11.0 || ^12.0",
         "timacdonald/callable-fake": "^1.0"
     },
     "autoload": {

--- a/src/ChannelFake.php
+++ b/src/ChannelFake.php
@@ -202,7 +202,7 @@ class ChannelFake implements LoggerInterface
      */
     public function write(string $level, $message, array $context = []): void
     {
-        $this->log($level, $message, $context);
+        $this->log($level, $message, $context); // @phpstan-ignore argument.type
     }
 
     /**

--- a/src/ChannelFake.php
+++ b/src/ChannelFake.php
@@ -178,6 +178,8 @@ class ChannelFake implements LoggerInterface
     }
 
     /**
+     * {@inheritdoc}
+     *
      * @see Logger::log()
      * @see LoggerInterface::log()
      */

--- a/src/ChannelFake.php
+++ b/src/ChannelFake.php
@@ -178,10 +178,10 @@ class ChannelFake implements LoggerInterface
     }
 
     /**
-     * {@inheritdoc}
-     *
      * @see Logger::log()
      * @see LoggerInterface::log()
+     *
+     * @param  string|\Stringable  $message
      */
     public function log($level, $message, array $context = []): void
     {
@@ -202,7 +202,6 @@ class ChannelFake implements LoggerInterface
      */
     public function write(string $level, $message, array $context = []): void
     {
-        /** @phpstan-ignore argument.type */
         $this->log($level, $message, $context);
     }
 

--- a/src/LogFake.php
+++ b/src/LogFake.php
@@ -205,6 +205,7 @@ class LogFake implements LoggerInterface
      * @see LogManager::log()
      * @see LoggerInterface::log()
      *
+     * @param  string|\Stringable  $message
      * @param  mixed  $level
      */
     public function log($level, $message, array $context = []): void

--- a/src/LogFake.php
+++ b/src/LogFake.php
@@ -42,7 +42,7 @@ class LogFake implements LoggerInterface
      */
     public static function bind(): LogFake
     {
-        $instance = new LogFake();
+        $instance = new LogFake;
 
         Log::swap($instance);
 

--- a/src/LogHelpers.php
+++ b/src/LogHelpers.php
@@ -10,6 +10,8 @@ trait LogHelpers
     /**
      * @see LogManager::emergency()
      * @see Logger::emergency()
+     *
+     * @param  string|\Stringable  $message
      */
     public function emergency($message, $context = []): void
     {
@@ -19,6 +21,8 @@ trait LogHelpers
     /**
      * @see LogManager::alert()
      * @see Logger::alert()
+     *
+     * @param  string|\Stringable  $message
      */
     public function alert($message, array $context = []): void
     {
@@ -28,6 +32,8 @@ trait LogHelpers
     /**
      * @see LogManager::critical()
      * @see Logger::critical()
+     *
+     * @param  string|\Stringable  $message
      */
     public function critical($message, array $context = []): void
     {
@@ -37,6 +43,8 @@ trait LogHelpers
     /**
      * @see LogManager::error()
      * @see Logger::error()
+     *
+     * @param  string|\Stringable  $message
      */
     public function error($message, array $context = []): void
     {
@@ -46,6 +54,8 @@ trait LogHelpers
     /**
      * @see LogManager::warning()
      * @see Logger::warning()
+     *
+     * @param  string|\Stringable  $message
      */
     public function warning($message, array $context = []): void
     {
@@ -55,6 +65,8 @@ trait LogHelpers
     /**
      * @see LogManager::notice()
      * @see Logger::notice()
+     *
+     * @param  string|\Stringable  $message
      */
     public function notice($message, array $context = []): void
     {
@@ -64,6 +76,8 @@ trait LogHelpers
     /**
      * @see LogManager::info()
      * @see Logger::info()
+     *
+     * @param  string|\Stringable  $message
      */
     public function info($message, array $context = []): void
     {
@@ -73,6 +87,8 @@ trait LogHelpers
     /**
      * @see LogManager::debug()
      * @see Logger::debug()
+     *
+     * @param  string|\Stringable  $message
      */
     public function debug($message, array $context = []): void
     {
@@ -82,6 +98,8 @@ trait LogHelpers
     /**
      * @see LogManager::log()
      * @see Logger::log()
+     *
+     * @param  string|\Stringable  $message
      */
     abstract public function log($level, $message, array $context = []): void;
 }

--- a/tests/AssertionTest.php
+++ b/tests/AssertionTest.php
@@ -9,9 +9,9 @@ use TiMacDonald\Log\LogFake;
 
 class AssertionTest extends TestCase
 {
-    public function testAssertLoggedFunc(): void
+    public function test_assert_logged_func(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         // default...
         self::assertFailsWithMessage(
@@ -62,9 +62,9 @@ class AssertionTest extends TestCase
         );
     }
 
-    public function testAssertLoggedArgs(): void
+    public function test_assert_logged_args(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $callable = new CallableFake(fn () => true);
         $log->info('expected message', ['expected' => 'context']);
 
@@ -75,9 +75,9 @@ class AssertionTest extends TestCase
         }, 1);
     }
 
-    public function testAssertLoggedCustomError(): void
+    public function test_assert_logged_custom_error(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         self::assertFailsWithMessage(
             fn () => $log->assertLogged(fn () => false, 'expected message'),
@@ -85,9 +85,9 @@ class AssertionTest extends TestCase
         );
     }
 
-    public function testAssertLoggedTimes(): void
+    public function test_assert_logged_times(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         // default...
         $log->info('xxxx');
@@ -145,9 +145,9 @@ class AssertionTest extends TestCase
         );
     }
 
-    public function testAssertLoggedTimesArgs(): void
+    public function test_assert_logged_times_args(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $callable = new CallableFake(fn () => true);
         $log->info('expected message', ['expected' => 'context']);
 
@@ -158,9 +158,9 @@ class AssertionTest extends TestCase
         }, 1);
     }
 
-    public function testAssertLoggedTimesCustomError(): void
+    public function test_assert_logged_times_custom_error(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         self::assertFailsWithMessage(
             fn () => $log->assertLoggedTimes(fn () => false, 3, 'expected message'),
@@ -168,9 +168,9 @@ class AssertionTest extends TestCase
         );
     }
 
-    public function testAssertNotLogged(): void
+    public function test_assert_not_logged(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         // default channel...
         $log->assertNotLogged(fn () => true);
@@ -203,9 +203,9 @@ class AssertionTest extends TestCase
         $log->stack(['c1', 'c2'], 'name')->assertNotLogged(fn () => false);
     }
 
-    public function testAssertNotLoggedArgs(): void
+    public function test_assert_not_logged_args(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $callable = new CallableFake(fn () => false);
         $log->info('expected message', ['expected' => 'context']);
 
@@ -216,9 +216,9 @@ class AssertionTest extends TestCase
         }, 1);
     }
 
-    public function testAssertNotLoggedCustomMessage(): void
+    public function test_assert_not_logged_custom_message(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $log->info('xxxx');
 
         self::assertFailsWithMessage(
@@ -227,9 +227,9 @@ class AssertionTest extends TestCase
         );
     }
 
-    public function testAssertNothingLogged(): void
+    public function test_assert_nothing_logged(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         // default channel...
         $log->assertNothingLogged();
@@ -256,9 +256,9 @@ class AssertionTest extends TestCase
         );
     }
 
-    public function testAssertNothingLoggedCustomError(): void
+    public function test_assert_nothing_logged_custom_error(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $log->info('xxxx');
 
         self::assertFailsWithMessage(
@@ -267,9 +267,9 @@ class AssertionTest extends TestCase
         );
     }
 
-    public function testAssertWasForgotten(): void
+    public function test_assert_was_forgotten(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         // default channel...
         self::assertFailsWithMessage(
@@ -294,9 +294,9 @@ class AssertionTest extends TestCase
         );
     }
 
-    public function testAssertWasForgottenCustomError(): void
+    public function test_assert_was_forgotten_custom_error(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         self::assertFailsWithMessage(
             fn () => $log->assertWasForgotten('expected message'),
@@ -304,9 +304,9 @@ class AssertionTest extends TestCase
         );
     }
 
-    public function testAssertWasForgottenTimes(): void
+    public function test_assert_was_forgotten_times(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         // default channel...
         self::assertFailsWithMessage(
@@ -332,9 +332,9 @@ class AssertionTest extends TestCase
         );
     }
 
-    public function testAssertWasForgottenTimesCustomError(): void
+    public function test_assert_was_forgotten_times_custom_error(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         self::assertFailsWithMessage(
             fn () => $log->assertWasForgottenTimes(3, 'expected message'),
@@ -342,9 +342,9 @@ class AssertionTest extends TestCase
         );
     }
 
-    public function testAssertWasNotForgotten(): void
+    public function test_assert_was_not_forgotten(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         // default channel...
         $log->assertWasNotForgotten();
@@ -369,9 +369,9 @@ class AssertionTest extends TestCase
         );
     }
 
-    public function testAssertWasNotForgottenCustomError(): void
+    public function test_assert_was_not_forgotten_custom_error(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $log->forgetChannel('stack');
 
         self::assertFailsWithMessage(
@@ -380,9 +380,9 @@ class AssertionTest extends TestCase
         );
     }
 
-    public function testAssertChannelIsCurrentlyForgotten(): void
+    public function test_assert_channel_is_currently_forgotten(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         self::assertFailsWithMessage(
             fn () => $log->assertChannelIsCurrentlyForgotten('channel'),
@@ -397,9 +397,9 @@ class AssertionTest extends TestCase
         $log->assertChannelIsCurrentlyForgotten('channel');
     }
 
-    public function testAssertChannelIsCurrentlyForgottenCustomMessage(): void
+    public function test_assert_channel_is_currently_forgotten_custom_message(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $log->channel('channel');
 
         self::assertFailsWithMessage(
@@ -408,9 +408,9 @@ class AssertionTest extends TestCase
         );
     }
 
-    public function testAssertCurrentContext(): void
+    public function test_assert_current_context(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         // default channel...
         $log->assertCurrentContext([]);
@@ -445,9 +445,9 @@ class AssertionTest extends TestCase
         );
     }
 
-    public function testAssertCurrentContextCustomMesage(): void
+    public function test_assert_current_context_custom_mesage(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         self::assertFailsWithMessage(
             fn () => $log->assertCurrentContext(fn () => false, 'expected message'),
@@ -455,9 +455,9 @@ class AssertionTest extends TestCase
         );
     }
 
-    public function testAssertCurrentContextWithClosure(): void
+    public function test_assert_current_context_with_closure(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         // default channel...
         $log->assertCurrentContext(fn () => true);
@@ -486,9 +486,9 @@ class AssertionTest extends TestCase
         );
     }
 
-    public function testAssertCurrentContextWithClosureArgs(): void
+    public function test_assert_current_context_with_closure_args(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $callable = new CallableFake(fn () => true);
 
         $log->withContext(['foo' => 'bar']);
@@ -504,9 +504,9 @@ class AssertionTest extends TestCase
         }, 1);
     }
 
-    public function testItCannotAssertCurrentContextForStacks(): void
+    public function test_it_cannot_assert_current_context_for_stacks(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot call [Log::stack(...)->assertCurrentContext(...)] as stack contexts are reset each time they are resolved from the LogManager.');
@@ -514,9 +514,9 @@ class AssertionTest extends TestCase
         $log->stack(['c1', 'c2'], 'name')->assertCurrentContext(['foo' => 'bar']);
     }
 
-    public function testAssertCurrentContextWithNonBoolReturnedFromClosure(): void
+    public function test_assert_current_context_with_non_bool_returned_from_closure(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         /** @phpstan-ignore argument.type */
         $log->assertCurrentContext(fn () => 1);
@@ -527,9 +527,9 @@ class AssertionTest extends TestCase
         );
     }
 
-    public function testAssertLoggedFuncWithNonBoolReturnedFromClosure(): void
+    public function test_assert_logged_func_with_non_bool_returned_from_closure(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $log->info('xxxx');
 
         /** @phpstan-ignore argument.type */
@@ -541,9 +541,9 @@ class AssertionTest extends TestCase
         );
     }
 
-    public function testAssertHasSharedContext(): void
+    public function test_assert_has_shared_context(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $log->shareContext(['shared' => 'context']);
 
         $log->assertHasSharedContext(fn ($context) => $context === ['shared' => 'context']);
@@ -553,9 +553,9 @@ class AssertionTest extends TestCase
         );
     }
 
-    public function testItCanProvideCustomMessageWithAssertHasSharedContext(): void
+    public function test_it_can_provide_custom_message_with_assert_has_shared_context(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $log->shareContext(['shared' => 'context']);
 
         self::assertFailsWithMessage(
@@ -564,9 +564,9 @@ class AssertionTest extends TestCase
         );
     }
 
-    public function testItCanPassContextArrayDirectlyToAssertHasSharedContext(): void
+    public function test_it_can_pass_context_array_directly_to_assert_has_shared_context(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $log->shareContext(['shared' => 'context']);
 
         $log->assertHasSharedContext(['shared' => 'context']);

--- a/tests/LogFakeApiTest.php
+++ b/tests/LogFakeApiTest.php
@@ -16,9 +16,9 @@ use TiMacDonald\Log\LogFake;
 
 class LogFakeApiTest extends TestCase
 {
-    public function testLoggingLevelMethods(): void
+    public function test_logging_level_methods(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         // default channel...
         $log->emergency('emergency log');
@@ -90,18 +90,18 @@ class LogFakeApiTest extends TestCase
         $log->stack(['c1', 'c2'], 'name')->assertLogged(fn (LogEntry $log): bool => $log->level === 'custom_2');
     }
 
-    public function testAssertChannelAndDriverMethodsCanBeUsedInterchangably(): void
+    public function test_assert_channel_and_driver_methods_can_be_used_interchangably(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         $log->driver('channel')->info('expected message');
 
         $log->channel('channel')->assertLogged(fn (): bool => true);
     }
 
-    public function testCurrentStackIsTakenIntoAccount(): void
+    public function test_current_stack_is_taken_into_account(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         $log->stack(['bugsnag', 'sentry'], 'dev_team')->info('expected message');
 
@@ -109,18 +109,18 @@ class LogFakeApiTest extends TestCase
         $log->stack(['bugsnag', 'sentry'], 'dev_team')->assertLogged(fn () => true);
     }
 
-    public function testCanHaveStackChannelsInAnyOrder(): void
+    public function test_can_have_stack_channels_in_any_order(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         $log->stack(['bugsnag', 'sentry'], 'dev_team')->info('expected message');
 
         $log->stack(['sentry', 'bugsnag'], 'dev_team')->assertLogged(fn () => true);
     }
 
-    public function testItDifferentiatesBetweenStacksWithANameAndThoseWithout(): void
+    public function test_it_differentiates_between_stacks_with_a_name_and_those_without(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         $log->stack(['bugsnag', 'sentry'], 'dev_team')->info('expected message');
         $log->stack(['bugsnag', 'sentry'])->alert('expected message');
@@ -131,9 +131,9 @@ class LogFakeApiTest extends TestCase
 
     // up to here...
 
-    public function testDifferentiatesBetweenStacksAndChannelsWithTheSameName(): void
+    public function test_differentiates_between_stacks_and_channels_with_the_same_name(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         $log->stack(['bugsnag', 'sentry'])->info('expected message');
         $log->channel('bugsnag,sentry')->alert('expected message');
@@ -148,9 +148,9 @@ class LogFakeApiTest extends TestCase
         $log->channel('name:bugsnag,sentry')->assertNotLogged(fn (LogEntry $log) => $log->level === 'info');
     }
 
-    public function testAssertLoggedInStackDotNotatesSortedChannels(): void
+    public function test_assert_logged_in_stack_dot_notates_sorted_channels(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         try {
             $log->stack(['c', 'b', 'a'], 'name')->assertLogged(fn () => false);
@@ -160,17 +160,17 @@ class LogFakeApiTest extends TestCase
         }
     }
 
-    public function testSetDefaultDriver(): void
+    public function test_set_default_driver(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $log->setDefaultDriver('expected-driver');
 
         self::assertSame('expected-driver', Config::get('logging.default'));
     }
 
-    public function testDummyMethods(): void
+    public function test_dummy_methods(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         $log->listen(function () {
             //
@@ -178,7 +178,7 @@ class LogFakeApiTest extends TestCase
         $log->extend('misc', function () {
             //
         });
-        $log->setEventDispatcher(new class() implements Dispatcher
+        $log->setEventDispatcher(new class implements Dispatcher
         {
             /**
              * @param  \Closure|string|array<string>  $events
@@ -268,9 +268,9 @@ class LogFakeApiTest extends TestCase
         self::assertSame($log->getLogger(), $log->channel());
     }
 
-    public function testItCanDumpDefaultChannel(): void
+    public function test_it_can_dump_default_channel(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $dumps = [];
         VarDumper::setHandler(static function (array $logs) use (&$dumps) {
             $dumps[] = $logs;
@@ -307,9 +307,9 @@ class LogFakeApiTest extends TestCase
         VarDumper::setHandler(null);
     }
 
-    public function testItCanDumpALevelForTheDefaultChannel(): void
+    public function test_it_can_dump_a_level_for_the_default_channel(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $dumps = [];
         VarDumper::setHandler(static function (array $logs) use (&$dumps) {
             $dumps[] = $logs;
@@ -334,9 +334,9 @@ class LogFakeApiTest extends TestCase
         VarDumper::setHandler(null);
     }
 
-    public function testItCanDumpAChannel(): void
+    public function test_it_can_dump_a_channel(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $dumps = [];
         VarDumper::setHandler(static function (array $logs) use (&$dumps) {
             $dumps[] = $logs;
@@ -371,9 +371,9 @@ class LogFakeApiTest extends TestCase
         VarDumper::setHandler(null);
     }
 
-    public function testItCanDumpALevelForAChannel(): void
+    public function test_it_can_dump_a_level_for_a_channel(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $dumps = [];
         VarDumper::setHandler(static function (array $logs) use (&$dumps) {
             $dumps[] = $logs;
@@ -401,9 +401,9 @@ class LogFakeApiTest extends TestCase
         VarDumper::setHandler(null);
     }
 
-    public function testItCanDumpAllLogsForAllChannels(): void
+    public function test_it_can_dump_all_logs_for_all_channels(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $dumps = [];
         VarDumper::setHandler(static function (array $logs) use (&$dumps) {
             $dumps[] = $logs;
@@ -455,9 +455,9 @@ class LogFakeApiTest extends TestCase
         VarDumper::setHandler(null);
     }
 
-    public function testItCanDumpAllLogsForAllChannelsButFilterByLevel(): void
+    public function test_it_can_dump_all_logs_for_all_channels_but_filter_by_level(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $dumps = [];
         VarDumper::setHandler(static function (array $logs) use (&$dumps) {
             $dumps[] = $logs;
@@ -495,20 +495,20 @@ class LogFakeApiTest extends TestCase
         VarDumper::setHandler(null);
     }
 
-    public function testItHandlesNullDriverConfig(): void
+    public function test_it_handles_null_driver_config(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         Config::set('logging.default', null);
 
         $log->info('xxxx');
         $log->channel('null')->assertLogged(fn () => true);
     }
 
-    public function testItCanLogStringableObjects(): void
+    public function test_it_can_log_stringable_objects(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $callable = new CallableFake(fn () => true);
-        $log->info(new class() implements Stringable
+        $log->info(new class implements Stringable
         {
             public function __toString(): string
             {
@@ -522,9 +522,9 @@ class LogFakeApiTest extends TestCase
         }, 1);
     }
 
-    public function testItAddsContextToLogs(): void
+    public function test_it_adds_context_to_logs(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $callable = new CallableFake(fn () => true);
 
         $log->withContext(['foo' => 'xxxx'])
@@ -543,9 +543,9 @@ class LogFakeApiTest extends TestCase
         }, 1);
     }
 
-    public function testItCanClearContext(): void
+    public function test_it_can_clear_context(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $callable = new CallableFake(fn () => true);
 
         $log->withContext(['foo' => 'xxxx'])
@@ -562,9 +562,9 @@ class LogFakeApiTest extends TestCase
         }, 1);
     }
 
-    public function testItCanFakeOnDemandChannels(): void
+    public function test_it_can_fake_on_demand_channels(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         $log->build([])->info('expected message 1');
         $log->channel('ondemand::{}')->assertLogged(fn (LogEntry $log) => $log->message === 'expected message 1');
@@ -573,16 +573,16 @@ class LogFakeApiTest extends TestCase
         $log->channel('ondemand::{"foo":"bar"}')->assertLogged(fn (LogEntry $log) => $log->message === 'expected message 2');
     }
 
-    public function testItCanRetrieveChannels(): void
+    public function test_it_can_retrieve_channels(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         $channel = $log->channel('expected-channel');
 
         self::assertSame(['expected-channel' => $channel], $log->getChannels());
     }
 
-    public function testItCanBindItselfToTheContainer(): void
+    public function test_it_can_bind_itself_to_the_container(): void
     {
         self::assertNotInstanceOf(LogFake::class, Log::getFacadeRoot());
 
@@ -591,9 +591,9 @@ class LogFakeApiTest extends TestCase
         self::assertSame($log, Log::getFacadeRoot());
     }
 
-    public function testItResetsStackContextOnChannelBuild(): void
+    public function test_it_resets_stack_context_on_channel_build(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         $stack1 = $log->stack(['c1'], 'name');
         $stack1->withContext(['bound' => 'context']);
@@ -611,9 +611,9 @@ class LogFakeApiTest extends TestCase
         });
     }
 
-    public function testItGivesStacksANameWhenNoneIsProvided(): void
+    public function test_it_gives_stacks_a_name_when_none_is_provided(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
 
         try {
             $log->stack(['c1'])->assertLogged(fn () => true);
@@ -623,9 +623,9 @@ class LogFakeApiTest extends TestCase
         }
     }
 
-    public function testItClearsContextWhenAChannelIsForgotten(): void
+    public function test_it_clears_context_when_a_channel_is_forgotten(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $log->channel('channel')->withContext(['foo' => 'bar']);
         $log->forgetChannel('channel');
         $log->channel('channel')->info('expected message');
@@ -633,9 +633,9 @@ class LogFakeApiTest extends TestCase
         $log->channel('channel')->assertLogged(fn (LogEntry $log) => $log->context === []);
     }
 
-    public function testItSupportsSharedContextForAlreadyBuiltDrivers(): void
+    public function test_it_supports_shared_context_for_already_built_drivers(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $channel = $log->channel('channel');
         $log->shareContext([
             'shared' => 'context',
@@ -650,9 +650,9 @@ class LogFakeApiTest extends TestCase
         ]);
     }
 
-    public function testItSupportsSharedContextForNewlyBuiltDrivers(): void
+    public function test_it_supports_shared_context_for_newly_built_drivers(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $log->shareContext([
             'shared' => 'context',
         ]);
@@ -667,9 +667,9 @@ class LogFakeApiTest extends TestCase
         ]);
     }
 
-    public function testItMergesSharedContext(): void
+    public function test_it_merges_shared_context(): void
     {
-        $log = new LogFake();
+        $log = new LogFake;
         $log->shareContext([
             'shared' => 'first',
             'more' => 'context',

--- a/tests/LogFakeApiTest.php
+++ b/tests/LogFakeApiTest.php
@@ -175,7 +175,7 @@ class LogFakeApiTest extends TestCase
         $log->listen(function () {
             //
         });
-        $log->extend('misc', function () {
+        $log->extend('misc', function () { // @phpstan-ignore method.resultUnused
             //
         });
         $log->setEventDispatcher(new class implements Dispatcher
@@ -264,7 +264,7 @@ class LogFakeApiTest extends TestCase
                 //
             }
         });
-        $log->getEventDispatcher();
+        $log->getEventDispatcher();  // @phpstan-ignore method.resultUnused
         self::assertSame($log->getLogger(), $log->channel());
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -18,7 +18,7 @@ class TestCase extends BaseTestCase
     {
         parent::setUp();
 
-        $app = Container::setInstance(new Container());
+        $app = Container::setInstance(new Container);
 
         $app->singleton('config', fn () => new Repository(['logging' => ['default' => 'stack']]));
         /** @phpstan-ignore argument.type */


### PR DESCRIPTION
I also had to set the minimum stability to `dev` instead of `stable`. But it should still install stable versions by default when available. So it is only used when explicitly requiring Laravel 12 before the launch.