### PR TITLE
Add assertLogIs and assertLogContains methods to channel

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,10 @@ public function testItLogsWhenAUserAuthenticates()
     Log::channel('slack')->assertLogged(
         fn (LogEntry $log) => $log->message === 'User logged in.'
     );
+    
+    // if you only care about the message:
+    Log::channel('slack')->assertLogIs('User logged in.');
+    Log::channel('slack')->assertLogContains('logged in');
 }
 ```
 

--- a/src/ChannelFake.php
+++ b/src/ChannelFake.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Psr\Log\LoggerInterface;
+use Stringable;
 
 class ChannelFake implements LoggerInterface
 {
@@ -76,6 +77,34 @@ class ChannelFake implements LoggerInterface
         PHPUnit::assertTrue(
             $this->logged($callback)->count() > 0,
             $message ?? "Expected log was not created in the [{$this->name}] channel."
+        );
+
+        return $this;
+    }
+
+    /**
+     * @link https://github.com/timacdonald/log-fake#assertLogIs Documentation
+     */
+    public function assertLogIs(string|Stringable $log, ?string $message = null): ChannelFake
+    {
+        $callback = fn (LogEntry $entry) => $entry->message === (string) $log;
+        PHPUnit::assertTrue(
+            $this->logged($callback)->count() > 0,
+            $message ?? "Expected log [$log] was not in the [{$this->name}] channel."
+        );
+
+        return $this;
+    }
+
+    /**
+     * @link https://github.com/timacdonald/log-fake#assertLogContains Documentation
+     */
+    public function assertLogContains(string|Stringable $log, ?string $message = null): ChannelFake
+    {
+        $callback = fn (LogEntry $entry) => str_contains($entry->message, (string) $log);
+        PHPUnit::assertTrue(
+            $this->logged($callback)->count() > 0,
+            $message ?? "Expected log partial [$log] was not in the [{$this->name}] channel."
         );
 
         return $this;

--- a/tests/AssertionTest.php
+++ b/tests/AssertionTest.php
@@ -158,6 +158,40 @@ class AssertionTest extends TestCase
         }, 1);
     }
 
+    public function test_assert_log_is(): void
+    {
+        $log = new LogFake;
+        $log->info('expected message', ['expected' => 'context']);
+        $log->assertLogIs('expected message');
+    }
+
+    public function test_assert_log_is_fails(): void
+    {
+        $log = new LogFake;
+
+        self::assertFailsWithMessage(
+            fn () => $log->assertLogIs('expected message'),
+            "Expected log [expected message] was not in the [stack] channel."
+        );
+    }
+
+    public function test_assert_log_contains(): void
+    {
+        $log = new LogFake;
+        $log->info('expected 123 message', ['expected' => 'context']);
+        $log->assertLogContains(' 123 ');
+    }
+
+    public function test_assert_log_contains_fails(): void
+    {
+        $log = new LogFake;
+        $log->info('expected 123 message', ['expected' => 'context']);
+        self::assertFailsWithMessage(
+            fn () => $log->assertLogContains(' 444 '),
+            "Expected log partial [ 444 ] was not in the [stack] channel."
+        );
+    }
+
     public function test_assert_logged_times_custom_error(): void
     {
         $log = new LogFake;


### PR DESCRIPTION
I personally found passing closures a bit fluffy.
Most of the time, I do not care about the log level or the context of the log and only need to check the log message.

```
    Log::channel('slack')->assertLogIs('User logged in.');
    Log::channel('slack')->assertLogContains('logged in');
```